### PR TITLE
Improve version pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # `actions`
 
 GitHub actions for Solana projects.
+
+| Name             | Description |
+|------------------|-------------|
+| `install-solana` | Install Solana CLI tool with optional caching and verify the installed version |

--- a/install-solana/README.md
+++ b/install-solana/README.md
@@ -5,11 +5,11 @@ Install Solana CLI tool with optional caching and verify the installed version.
 ```yaml
 - uses: solana-program/actions/install-solana@v1
   with:
-    release: stable
+    version: stable
     cache: true
 ```
 
 - Inputs:
-  - `release`: The Solana CLI release to install, either as a version number (e.g., `v2.0.3`) or symbolic channel (`stable`, `beta` or `edge`). When specifying a version number, the version must be prefixed with a `v` (e.g., `v2.0.3`). Default to `stable`.
-  - `cache`: Whether the downloaded Solana CLI release should be cached. Defaults to `true`.
-  - `base-url`: The base URL to download the Solana CLI release from. Defaults to `https://release.solana.com` for Solana versions below 1.18.19 and `https://release.anza.xyz` for versions 1.18.19 and above or symbolic channels.
+  - `version`: The Solana CLI version to install, either as a version number (e.g., `2.0.3`) or symbolic channel (`stable`, `beta` or `edge`). Default to `stable`.
+  - `cache`: Whether the downloaded Solana CLI binary should be cached. Defaults to `true`.
+  - `base-url`: The base URL to download the Solana CLI. Defaults to `https://release.solana.com` for Solana versions below 1.18.19 and `https://release.anza.xyz` for versions 1.18.19 and above or symbolic channels.

--- a/install-solana/action.yml
+++ b/install-solana/action.yml
@@ -1,22 +1,22 @@
 name: Install Solana CLI
 
 inputs:
-  release:
+  version:
     description: The Solana CLI version to install
     required: true
     default: "stable"
   cache:
-    description: Whether the downloaded Solana CLI release should be cached
+    description: Whether the downloaded Solana CLI binary should be cached
     required: true
     default: "true"
   base_url:
-    description: The base URL to download the Solana CLI release from — e.g. https://release.anza.com.
+    description: The base URL to download the Solana CLI from — e.g. https://release.anza.com.
     required: false
 
 runs:
   using: "composite"
   steps:
-    - name: Cache Release
+    - name: Cache Version
       id: cache
       if: inputs.cache == 'true'
       uses: actions/cache@v4
@@ -24,35 +24,41 @@ runs:
         path: |
           ~/.local/share/solana/install/releases
           ~/.cache/solana
-        key: ${{ runner.os }}-solana-${{ inputs.release }}
+        key: ${{ runner.os }}-solana-${{ inputs.version }}
 
-    - name: Resolve Base URL
-      id: base_url
+    - name: Resolve Inputs
+      id: resolve
       run: |
         if [ "${{ inputs.base_url }}" != "" ]; then
           echo "base_url='${{ inputs.base_url }}'" >> $GITHUB_OUTPUT
         else
           cutoff="1.18.19"
-          desired="${{ inputs.release }}"
-          if [ "$(printf '%s\n' "$cutoff" "$desired" | sort -V | head -n1)" = "$desired" ] && [ "$cutoff" != "$desired" ]; then
+          desired="${{ inputs.version }}"
+          if [ "$(printf '%s\n' "$cutoff" "${desired#v}" | sort -V | head -n1)" = "${desired#v}" ] && [ "$cutoff" != "${desired#v}" ]; then
             echo "base_url='https://release.solana.com'" >> $GITHUB_OUTPUT
           else
             echo "base_url='https://release.anza.xyz'" >> $GITHUB_OUTPUT
           fi
+        fi
+
+        if [[ $desired =~ ^\d+\.\d+\.\d$ ]]; then
+          echo "version='v$desired'" >> $GITHUB_OUTPUT
+        else
+          echo "version='$desired'" >> $GITHUB_OUTPUT
         fi
       shell: bash
 
     - name: Install Solana CLI
       if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'
       run: |
-        sh -c "$(curl -sSfL ${{ steps.base_url.outputs.base_url }}/${{ inputs.release }}/install)"
+        sh -c "$(curl -sSfL ${{ steps.resolve.outputs.base_url }}/${{ steps.resolve.outputs.version }}/install)"
       shell: bash
 
     - name: Set Active Version
       run: |
         rm -f "$HOME/.local/share/solana/install/active_release"
-        RELEASE=$(ls -d $HOME/.local/share/solana/install/releases/*)
-        ln -s "$RELEASE/solana-release" "$HOME/.local/share/solana/install/active_release"
+        release=$(ls -d $HOME/.local/share/solana/install/releases/*)
+        ln -s "$release/solana-release" "$HOME/.local/share/solana/install/active_release"
       shell: bash
 
     - name: Add Binary to Path


### PR DESCRIPTION
### Problem

The `install-solana` action requires version numbers to be prefixed with `v`, since it supports both version and channel releases.

### Solution

This PR relaxes this requirement by allowing the `version` to be specified as version numbers with or without `v` prefix or a release channel.