### PR TITLE
Make `desired` variable in `install-solana` accessible when `base_url` is provided

### DIFF
--- a/install-solana/action.yml
+++ b/install-solana/action.yml
@@ -29,11 +29,12 @@ runs:
     - name: Resolve Inputs
       id: resolve
       run: |
+        desired="${{ inputs.version }}"
+
         if [ "${{ inputs.base_url }}" != "" ]; then
           echo "base_url='${{ inputs.base_url }}'" >> $GITHUB_OUTPUT
         else
           cutoff="1.18.19"
-          desired="${{ inputs.version }}"
           if [ "$(printf '%s\n' "$cutoff" "${desired#v}" | sort -V | head -n1)" = "${desired#v}" ] && [ "$cutoff" != "${desired#v}" ]; then
             echo "base_url='https://release.solana.com'" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Currently, when we pass a `base_url` input, the `desired` variable is never instantiated and therefore the `version` output is always empty.