### PR TITLE
Add a reusable setup action

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ GitHub actions for Solana projects.
 | Name             | Description |
 |------------------|-------------|
 | `install-solana` | Install Solana CLI tool with optional caching and verify the installed version |
+| `setup-ubuntu` | Setup Ubuntu runner for program repo CI jobs |

--- a/setup-ubuntu/README.md
+++ b/setup-ubuntu/README.md
@@ -1,0 +1,32 @@
+# Setup Ubuntu runner
+
+Install requirements for running program repo CI jobs.
+
+```yaml
+- uses: solana-program/actions/setup-ubuntu@v1
+  with:
+    cargo-cache-key: my-cache-key-specific
+    cargo-cache-fallback-key: my-cache-key
+    cargo-cache-local-key: my-local-cache-key
+    pnpm: true
+    stable-toolchain: true
+    nightly-toolchain: "nightly-2025-02-16"
+    clippy: true
+    rustfmt: true
+    solana: "2.3.4"
+    cli: true
+    purge: true
+```
+
+- Inputs:
+  - `cargo-cache-key`: The key to cache cargo dependencies. Skips cargo caching if not provided.
+  - `cargo-cache-fallback-key`: The fallback key to use when caching cargo dependencies. Default to not using a fallback key.
+  - `cargo-cache-local-key`: The key to cache local cargo dependencies. Skips local cargo caching if not provided.
+  - `pnpm`: Install pnpm if `true`. Defaults to `false`.
+  - `stable-toolchain`: Install stable toolchain specified in `rust-toolchain.toml` if `true`. Defaults to `false`.
+  - `nightly-toolchain`: Install nightly toolchain specified as cargo invocations, e.g. `"nightly-2025-02-16"`.
+  - `clippy`: Install Clippy with the nightly toolchain specified in `nightly-toolchain` if `true`. Defaults to `false`. Requires `nightly-toolchain`.
+  - `rustfmt`: Install Rustfmt with the nightly toolchain specified in `nightly-toolchain` if `true`. Defaults to `false`. Requires `nightly-toolchain`.
+  - `solana`: Install Solana specified as a major-minor-patch version, e.g. `"2.3.4"`.
+  - `cli`: Install CLI dependencies if `true`. Defaults to `false`.
+  - `purge`: Purge unused ubuntu runner directories if `true`. Defaults to `false`.

--- a/setup-ubuntu/action.yml
+++ b/setup-ubuntu/action.yml
@@ -19,6 +19,7 @@ inputs:
   nightly-toolchain:
     description: Install nightly toolchain specified as cargo invocations, e.g. `"nightly-2025-02-16"`.
     required: false
+    default: 'false'
   clippy:
     description: Install Clippy with the nightly toolchain specified in `nightly-toolchain` if `true`. Defaults to `false`. Requires `nightly-toolchain`.
     required: false
@@ -28,6 +29,7 @@ inputs:
   solana:
     description: Install Solana specified as a major-minor-patch version, e.g. `"2.3.4"`.
     required: false
+    default: 'false'
   cli:
     description: Install CLI dependencies if `true`. Defaults to `false`.
     required: false
@@ -101,7 +103,7 @@ runs:
         toolchain: ${{ env.RUST_TOOLCHAIN_STABLE }}
 
     - name: Install nightly toolchain
-      if: ${{ inputs.nightly-toolchain == 'true' }}
+      if: ${{ inputs.nightly-toolchain != 'false' }}
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.nightly-toolchain }}
@@ -121,7 +123,7 @@ runs:
         components: clippy
 
     - name: Install Solana
-      if: ${{ inputs.solana == 'true' }}
+      if: ${{ inputs.solana != 'false' }}
       uses: solana-program/actions/install-solana@v1
       with:
         version: ${{ inputs.solana }}

--- a/setup-ubuntu/action.yml
+++ b/setup-ubuntu/action.yml
@@ -1,0 +1,174 @@
+name: Setup Ubuntu runner environment
+
+inputs:
+  cargo-cache-key:
+    description: The key to cache cargo dependencies. Skips cargo caching if not provided.
+    required: false
+  cargo-cache-fallback-key:
+    description: The fallback key to use when caching cargo dependencies. Default to not using a fallback key.
+    required: false
+  cargo-cache-local-key:
+    description: The key to cache local cargo dependencies. Skips local cargo caching if not provided.
+    required: false
+  pnpm:
+    description: Install pnpm if `true`. Defaults to `false`.
+    required: false
+  stable-toolchain:
+    description: Install stable toolchain if `true`. Defaults to `false`.
+    required: false
+  nightly-toolchain:
+    description: Install nightly toolchain specified as cargo invocations, e.g. `"nightly-2025-02-16"`.
+    required: false
+  clippy:
+    description: Install Clippy with the nightly toolchain specified in `nightly-toolchain` if `true`. Defaults to `false`. Requires `nightly-toolchain`.
+    required: false
+  rustfmt:
+    description: Install Rustfmt with the nightly toolchain specified in `nightly-toolchain` if `true`. Defaults to `false`. Requires `nightly-toolchain`.
+    required: false
+  solana:
+    description: Install Solana specified as a major-minor-patch version, e.g. `"2.3.4"`.
+    required: false
+  cli:
+    description: Install CLI dependencies if `true`. Defaults to `false`.
+    required: false
+  purge:
+    description: Purge unused directories if `true`. Defaults to `false`.
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set Environment Variables
+      shell: bash
+      run: |
+        RUST_TOOLCHAIN_STABLE=$(tail -n1 ./rust-toolchain.toml | sed "s/channel = \"\(.*\)\"/\1/")
+        echo "RUST_TOOLCHAIN_STABLE=$RUST_TOOLCHAIN_STABLE" >> "$GITHUB_ENV"
+
+    - name: Setup pnpm
+      if: ${{ inputs.pnpm == 'true' }}
+      uses: pnpm/action-setup@v4
+
+    - name: Setup Node.js
+      if: ${{ inputs.pnpm == 'true' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'pnpm'
+
+    - name: Install Dependencies
+      if: ${{ inputs.pnpm == 'true' }}
+      run: pnpm install --frozen-lockfile
+      shell: bash
+
+    - name: Purge unused ubuntu runner directories
+      if: ${{ inputs.purge == 'true' }}
+      shell: bash
+      run: |
+        # If there are still disk space issues, try to add more packages from
+        # https://github.com/jlumbroso/free-disk-space
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/share/mysql
+        sudo rm -rf /usr/share/az_*
+        sudo rm -rf /usr/share/postgresql-common
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /opt/az
+        sudo rm -rf /opt/pipx
+        sudo rm -rf /opt/microsoft
+        sudo rm -rf /opt/google
+        sudo rm -rf /opt/hostedtoolcache
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/lib/heroku
+        sudo rm -rf /imagegeneration
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo docker image prune --all --force
+        # This packages aren't that big, ~500MB total
+        #sudo apt-get remove -y '^php.*' --fix-missing
+        #sudo apt-get remove -y '^dotnet-.*' --fix-missing
+        #sudo apt-get remove -y '^mongodb-.*' --fix-missing
+        #sudo apt-get remove -y '^mysql-.*' --fix-missing
+        sudo apt-get remove -y '^aspnetcore-.*' azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri google-cloud-cli --fix-missing
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+        #sudo swapoff -a
+        #sudo rm -f /mnt/swapfile
+
+    - name: Install stable toolchain
+      if: ${{ inputs.stable-toolchain == 'true' }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.RUST_TOOLCHAIN_STABLE }}
+
+    - name: Install nightly toolchain
+      if: ${{ inputs.nightly-toolchain == 'true' }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ inputs.nightly-toolchain }}
+
+    - name: Install Rustfmt
+      if: ${{ inputs.rustfmt == 'true' }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ inputs.nightly-toolchain }}
+        components: rustfmt
+
+    - name: Install Clippy
+      if: ${{ inputs.clippy == 'true' }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ inputs.nightly-toolchain }}
+        components: clippy
+
+    - name: Install Solana
+      if: ${{ inputs.solana == 'true' }}
+      uses: solana-program/actions/install-solana@v1
+      with:
+        version: ${{ inputs.solana }}
+        cache: true
+
+    - name: Install CLI dependencies
+      if: ${{ inputs.cli == 'true' }}
+      shell: bash
+      run: sudo apt update && sudo apt install libudev-dev protobuf-compiler libclang-dev -y
+
+    - name: Cache Cargo Dependencies
+      if: ${{ inputs.cargo-cache-key && !inputs.cargo-cache-fallback-key }}
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ inputs.cargo-cache-key }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.cargo-cache-key }}
+
+    - name: Cache Cargo Dependencies With Fallback
+      if: ${{ inputs.cargo-cache-key && inputs.cargo-cache-fallback-key }}
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ inputs.cargo-cache-key }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cargo-cache-key }}
+          ${{ runner.os }}-${{ inputs.cargo-cache-fallback-key }}-${{ hashFiles('**/Cargo.lock') }}
+          ${{ runner.os }}-${{ inputs.cargo-cache-fallback-key }}
+
+    - name: Cache Local Cargo Dependencies
+      if: ${{ inputs.cargo-cache-local-key }}
+      uses: actions/cache@v4
+      with:
+        path: |
+          .cargo/bin/
+          .cargo/registry/index/
+          .cargo/registry/cache/
+          .cargo/git/db/
+        key: ${{ runner.os }}-${{ inputs.cargo-cache-local-key }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.cargo-cache-local-key }}

--- a/setup-ubuntu/action.yml
+++ b/setup-ubuntu/action.yml
@@ -13,19 +13,21 @@ inputs:
   pnpm:
     description: Install pnpm if `true`. Defaults to `false`.
     required: false
-  stable-toolchain:
-    description: Install stable toolchain if `true`. Defaults to `false`.
+  default-toolchain:
+    description: Install default toolchain if `true`. Defaults to `false`.
     required: false
   nightly-toolchain:
     description: Install nightly toolchain specified as cargo invocations, e.g. `"nightly-2025-02-16"`.
     required: false
     default: 'false'
-  clippy:
-    description: Install Clippy with the nightly toolchain specified in `nightly-toolchain` if `true`. Defaults to `false`. Requires `nightly-toolchain`.
+  clippy-toolchain:
+    description: Install Clippy with the specified toolchain.
     required: false
-  rustfmt:
-    description: Install Rustfmt with the nightly toolchain specified in `nightly-toolchain` if `true`. Defaults to `false`. Requires `nightly-toolchain`.
+    default: 'false'
+  rustfmt-toolchain:
+    description: Install Rustfmt with the specified toolchain.
     required: false
+    default: 'false'
   solana:
     description: Install Solana specified as a major-minor-patch version, e.g. `"2.3.4"`.
     required: false
@@ -43,8 +45,8 @@ runs:
     - name: Set Environment Variables
       shell: bash
       run: |
-        RUST_TOOLCHAIN_STABLE=$(tail -n1 ./rust-toolchain.toml | sed "s/channel = \"\(.*\)\"/\1/")
-        echo "RUST_TOOLCHAIN_STABLE=$RUST_TOOLCHAIN_STABLE" >> "$GITHUB_ENV"
+        RUST_TOOLCHAIN_DEFAULT=$(grep "channel =" ./rust-toolchain.toml | sed "s/channel = \"\(.*\)\"/\1/")
+        echo "RUST_TOOLCHAIN_DEFAULT=$RUST_TOOLCHAIN_DEFAULT" >> "$GITHUB_ENV"
 
     - name: Setup pnpm
       if: ${{ inputs.pnpm == 'true' }}
@@ -96,11 +98,11 @@ runs:
         #sudo swapoff -a
         #sudo rm -f /mnt/swapfile
 
-    - name: Install stable toolchain
-      if: ${{ inputs.stable-toolchain == 'true' }}
+    - name: Install default toolchain
+      if: ${{ inputs.default-toolchain == 'true' }}
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ env.RUST_TOOLCHAIN_STABLE }}
+        toolchain: ${{ env.RUST_TOOLCHAIN_DEFAULT }}
 
     - name: Install nightly toolchain
       if: ${{ inputs.nightly-toolchain != 'false' }}
@@ -109,17 +111,17 @@ runs:
         toolchain: ${{ inputs.nightly-toolchain }}
 
     - name: Install Rustfmt
-      if: ${{ inputs.rustfmt == 'true' }}
+      if: ${{ inputs.rustfmt-toolchain != 'false' }}
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ inputs.nightly-toolchain }}
+        toolchain: ${{ inputs.rustfmt-toolchain }}
         components: rustfmt
 
     - name: Install Clippy
-      if: ${{ inputs.clippy == 'true' }}
+      if: ${{ inputs.clippy-toolchain != 'false' }}
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ inputs.nightly-toolchain }}
+        toolchain: ${{ inputs.clippy-toolchain }}
         components: clippy
 
     - name: Install Solana


### PR DESCRIPTION
#### Problem

All of the program repos have their own version of the "setup" action for Ubuntu runners, which is annoying to manage.

#### Summary of changes

Add a new `setup-ubuntu` reusable job that will install Solana, Rust, pnpm, etc as needed. You can see this being used at https://github.com/solana-program/token-2022/pull/667 from my branch currently