### PR TITLE
Add reusable publish-js workflow

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -23,6 +23,10 @@ on:
         description: Version level
         required: true
         type: string
+      tag:
+        description: NPM Tag (and preid for pre-releases)
+        required: true
+        type: string
       create-release:
         description: Create a GitHub release
         required: true
@@ -115,7 +119,7 @@ jobs:
         shell: bash
         run: |
           echo "old_git_tag=$(make git-tag-js-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
-          make publish-js-${{ inputs.level }}-${{ inputs.target }}
+          LEVEL=${{ inputs.level }} TAG=${{ inputs.tag }} make publish-js-${{ inputs.target }}
           echo "new_git_tag=$(make git-tag-js-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
 
       - name: Git Commit Bump, Tag, and Push

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -1,0 +1,139 @@
+name: Publish JS
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: Target
+        required: true
+        type: string
+      solana-cli-version:
+        description: Install Solana specified as a major-minor-patch version, e.g. `"2.3.4"`.
+        required: true
+        type: string
+      sbpf-program-packages:
+        description: SBPF programs to build and test as a string of space-separated targets, e.g. `package package2`.
+        required: false
+        type: string
+      package-path:
+        description: Path to directory with package to release
+        required: true
+        type: string
+      level:
+        description: Version level
+        required: true
+        type: string
+      tag:
+        description: NPM Tag (and preid for pre-releases)
+        required: true
+        type: string
+      create-release:
+        description: Create a GitHub release
+        required: true
+        type: boolean
+
+jobs:
+  test:
+    name: Test package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: solana-program/actions/setup-ubuntu@main
+        with:
+          solana: ${{ inputs.solana-cli-version }}
+          cargo-cache-key: cargo-publish-js-test-${{ inputs.package-path }}
+          cargo-cache-fallback-key: cargo-publish-js-test
+
+      - name: Format
+        run: make format-check-${{ inputs.target }}
+
+      - name: Lint
+        run: make lint-${{ inputs.target }}
+
+      - name: Build programs
+        shell: bash
+        run: |
+          for $program in ${{ inputs.sbpf-program-packages }}
+          do
+            make build-sbf-$program
+          done
+
+      - name: Test
+        run: make test-${{ inputs.target }}
+
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: write
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ANZA_TEAM_PAT }}
+          fetch-depth: 0 # get the whole history for git-cliff
+
+      - name: Setup Environment
+        uses: solana-program/actions/setup-ubuntu@main
+        with:
+          pnpm: true
+
+      - name: NPM Authentication
+        env:
+          SOLANA_NPM_TOKEN: ${{ secrets.SOLANA_NPM_TOKEN }}
+          SOLANA_PROGRAM_NPM_TOKEN: ${{ secrets.SOLANA_PROGRAM_NPM_TOKEN }}
+        shell: bash
+        run: |
+          cd "${{ inputs.package-path }}"
+          org="$(jq '.name|split("/")|.[0]' package.json)"
+          if [[ $org == "\"@solana-program\"" ]] then
+            if [ -z ${SOLANA_PROGRAM_NPM_TOKEN} ]; then
+              echo "The SOLANA_PROGRAM_NPM_TOKEN secret variable is not set"
+              echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
+              exit 1
+            fi
+            pnpm config set '//registry.npmjs.org/:_authToken' "${SOLANA_PROGRAM_NPM_TOKEN}"
+          elif [[ $org == "\"@solana\"" ]] then
+            if [ -z ${SOLANA_NPM_TOKEN} ]; then
+              echo "The SOLANA_NPM_TOKEN secret variable is not set"
+              echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
+              exit 1
+            fi
+            pnpm config set '//registry.npmjs.org/:_authToken' "${SOLANA_NPM_TOKEN}"
+          else
+            echo "Unknown organization: $org"
+            exit 1
+          fi
+
+      - name: Set Git Author
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Publish
+        id: publish
+        run: ./scripts/publish-js.sh "${{ inputs.package-path }}" ${{ inputs.level }} ${{ inputs.tag }}
+
+      - name: Push Commit and Tag
+        run: git push origin --follow-tags
+
+      - name: Generate a changelog
+        if: github.event.inputs.create-release == 'true'
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: "scripts/cliff.toml"
+          args: ${{ steps.publish.outputs.old_git_tag }}..HEAD --include-path "${{ inputs.package-path }}/**" --github-repo ${{ github.repository }}
+        env:
+          OUTPUT: TEMP_CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create GitHub release
+        if: github.event.inputs.create-release == 'true'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.publish.outputs.new_git_tag }}
+          bodyFile: TEMP_CHANGELOG.md

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -23,10 +23,6 @@ on:
         description: Version level
         required: true
         type: string
-      tag:
-        description: NPM Tag (and preid for pre-releases)
-        required: true
-        type: string
       create-release:
         description: Create a GitHub release
         required: true
@@ -56,7 +52,7 @@ jobs:
       - name: Build programs
         shell: bash
         run: |
-          for $program in ${{ inputs.sbpf-program-packages }}
+          for program in ${{ inputs.sbpf-program-packages }}
           do
             make build-sbf-$program
           done
@@ -116,10 +112,18 @@ jobs:
 
       - name: Publish
         id: publish
-        run: ./scripts/publish-js.sh "${{ inputs.package-path }}" ${{ inputs.level }} ${{ inputs.tag }}
+        shell: bash
+        run: |
+          echo "old_git_tag=$(make git-tag-js-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
+          make publish-js-${{ inputs.level }}-${{ inputs.target }}
+          echo "new_git_tag=$(make git-tag-js-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
 
-      - name: Push Commit and Tag
-        run: git push origin --follow-tags
+      - name: Git Commit Bump, Tag, and Push
+        shell: bash
+        run: |
+          git commit -am "Publish ${{ steps.publish.outputs.new_git_tag }}"
+          git tag -a "${{ steps.publish.outputs.new_git_tag }}" -m "Publish ${{ steps.publish.outputs.new_git_tag }}"
+          git push origin --follow-tags
 
       - name: Generate a changelog
         if: github.event.inputs.create-release == 'true'


### PR DESCRIPTION
#### Problem

The publish jobs are all over the place in the different program repos, which makes maintenance a hassle between the ~20 repos.

#### Summary of changes

This is very similar to #5, but for the publish js workflow.