### PR TITLE
main: Make js jobs consistent

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,10 +50,10 @@ jobs:
           pnpm: true
 
       - name: Format
-        run: make format-check-${{ matrix.package }}
+        run: make format-check-js-${{ matrix.package }}
 
       - name: Lint
-        run: make lint-${{ matrix.package }}
+        run: make lint-js-${{ matrix.package }}
 
   audit:
     name: Audit
@@ -258,5 +258,5 @@ jobs:
           path: ./target/deploy/*.so
           key: ${{ runner.os }}-program-builds-${{ github.sha }}
 
-      - name: Test Client JS
-        run: make test-${{ matrix.package }}
+      - name: Test
+        run: make test-js-${{ matrix.package }}


### PR DESCRIPTION
#### Problem

In the publish recipe, we use the `publish-js-%` prefix, so that a recipe can be something like `publish-js-patch-clients-js-legacy`, which is inconsistent with the other js jobs, which doesn't include `js` or the start of the path, ie `test-js-legacy`.

#### Summary of changes

Make things consistent, add a js prefix to all js jobs.