### PR TITLE
main: Delete characters instead of trying to parse as JSON

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          for program in $(echo '${{ inputs.sbpf-program-packages }}' | jq -r '.[]')
+          for program in $(echo "${{ inputs.sbpf-program-packages }}" | tr -d "'[],")
           do
             make build-sbf-${program}
           done


### PR DESCRIPTION
#### Problem

The main job is failing to build programs because it's not parsing the JSON string correctly.

#### Summary of changes

Rather than trying to parse as JSON, trim characters and process as a bash array.