### PR TITLE
publish-rust: Call `clippy-` instead of `lint-`

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Format
         run: make format-check-${{ inputs.target }}
 
-      - name: Lint
-        run: make lint-${{ inputs.target }}
+      - name: Clippy
+        run: make clippy-${{ inputs.target }}
 
       - name: Build programs
         shell: bash


### PR DESCRIPTION
#### Problem

I got the name of the lint job wrong -- it's `clippy-` and not `lint-`.

#### Summary of changes

Call `clippy-` instead.