### PR TITLE
publish-rust: Add trusted publishing, SLSA provenance, and GitHub App

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -113,13 +113,11 @@ jobs:
           fi
 
       - name: Set Git Author (required for cargo-release)
-        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
       - name: Set Version
-        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
         run: |
           if [ "${{ inputs.level }}" == "version" ]; then
             LEVEL=${{ inputs.version }}
@@ -127,6 +125,30 @@ jobs:
             LEVEL=${{ inputs.level }}
           fi
           cargo release $LEVEL --manifest-path "${{ inputs.package-path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
+
+      - name: Write check summary
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_SHA: ${{ github.sha }}
+          TARGET: ${{ inputs.target }}
+          BUMP_LEVEL: ${{ inputs.level }}
+          PACKAGE_PATH: ${{ inputs.package-path }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          CREATE_RELEASE: ${{ inputs.create-release }}
+        run: |
+          NEW_TAG=$(make "git-tag-rust-${TARGET}")
+          SHORT_SHA=${GH_SHA:0:7}
+          {
+            echo "## Check summary"
+            echo ""
+            echo "- **Tag:** \`${NEW_TAG}\`"
+            echo "- **Bump level:** \`${BUMP_LEVEL}\`"
+            echo "- **Package path:** \`${PACKAGE_PATH}\`"
+            echo "- **Dry run:** \`${DRY_RUN}\`"
+            echo "- **Create release:** \`${CREATE_RELEASE}\`"
+            echo "- **Ref:** ${GH_SHA} ([${GH_REPO}@${SHORT_SHA}](https://github.com/${GH_REPO}/commit/${GH_SHA}))"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Check semver
         if: ${{ steps.has_lib.outputs.has_lib == 'true' }}

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -143,10 +143,17 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Git Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.ANZA_TEAM_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
           fetch-depth: 0 # get the whole history for git-cliff
 
       - name: Setup Environment
@@ -162,9 +169,12 @@ jobs:
           tool: toml-cli,cargo-release@0.25.18
 
       - name: Set Git Author
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf https://github.com/
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
         id: auth

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -135,9 +135,13 @@ jobs:
   publish:
     name: Publish Rust Crate
     runs-on: ubuntu-latest
+    environment: prod
     needs: [test, semver]
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -157,24 +161,18 @@ jobs:
         with:
           tool: toml-cli,cargo-release@0.25.18
 
-      - name: Ensure CARGO_REGISTRY_TOKEN variable is set
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        if: ${{ env.CARGO_REGISTRY_TOKEN == '' }}
-        run: |
-          echo "The CARGO_REGISTRY_TOKEN secret variable is not set"
-          echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
-          exit 1
-
       - name: Set Git Author
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
+        id: auth
+
       - name: Publish Crate
         id: publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           if [ "${{ inputs.level }}" == "version" ]; then
             LEVEL=${{ inputs.version }}
@@ -191,6 +189,14 @@ jobs:
           echo "old_git_tag=$(make git-tag-rust-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
           LEVEL=${LEVEL} make publish-rust-${OPTIONS}${{ inputs.target }}
           echo "new_git_tag=$(make git-tag-rust-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
+
+      - name: Generate SLSA provenance
+        if: ${{ inputs.dry-run == false }}
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4.1.0
+        env:
+          NODE_OPTIONS: "--max-http-header-size=32768"
+        with:
+          subject-path: target/package/*.crate
 
       - name: Generate a changelog
         if: github.event.inputs.create-release == 'true'


### PR DESCRIPTION
## Summary

Removes `CARGO_REGISTRY_TOKEN` and `ANZA_TEAM_PAT` from the Rust publish workflow.

- Trusted publishing: crates.io authenticates the workflow via OIDC instead of a static token
- SLSA provenance: a signed attestation is recorded for each published `.crate`, verifiable with `gh attestation verify`
- GitHub App: replaces the PAT for git operations, enabling a tag protection ruleset that only the App can bypass
- Environment gate: the publish job runs under `environment: prod`, allowing consuming repos to require manual approval before any secrets are accessed

## Setup required in each of the 18 repos that are using this

- Create a `prod` environment with `APP_ID` variable and `PRIVATE_KEY` secret
- Install the GitHub App with `Contents: read and write`
- Configure crates.io trusted publishing for each crate (workflow: caller workflow file, environment: `prod`)
- Restrict tag creation to the github app