### PR TITLE
publish-js: add npm trusted publishing + gh app release flow

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -65,6 +65,30 @@ jobs:
       - name: Test
         run: make test-js-${{ inputs.target }}
 
+      - name: Write check summary
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_SHA: ${{ github.sha }}
+          TARGET: ${{ inputs.target }}
+          BUMP_LEVEL: ${{ inputs.level }}
+          NPM_TAG: ${{ inputs.tag }}
+          PACKAGE_PATH: ${{ inputs.package-path }}
+          CREATE_RELEASE: ${{ inputs.create-release }}
+        run: |
+          CURRENT_TAG=$(make "git-tag-js-${TARGET}")
+          SHORT_SHA=${GH_SHA:0:7}
+          {
+            echo "## Check summary"
+            echo ""
+            echo "- **Tag (current):** \`${CURRENT_TAG}\`"
+            echo "- **Bump level:** \`${BUMP_LEVEL}\`"
+            echo "- **NPM dist-tag:** \`${NPM_TAG}\`"
+            echo "- **Package path:** \`${PACKAGE_PATH}\`"
+            echo "- **Create release:** \`${CREATE_RELEASE}\`"
+            echo "- **Ref:** ${GH_SHA} ([${GH_REPO}@${SHORT_SHA}](https://github.com/${GH_REPO}/commit/${GH_SHA}))"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   publish:
     name: Publish package
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -68,15 +68,23 @@ jobs:
   publish:
     name: Publish package
     runs-on: ubuntu-latest
+    environment: prod
     needs: test
     permissions:
       contents: write
       id-token: write
     steps:
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Git Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.ANZA_TEAM_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
           fetch-depth: 0 # get the whole history for git-cliff
 
       - name: Setup Environment
@@ -84,35 +92,18 @@ jobs:
         with:
           pnpm: true
 
-      - name: NPM Authentication
-        env:
-          SOLANA_PROGRAM_NPM_TOKEN: ${{ secrets.SOLANA_PROGRAM_NPM_TOKEN }}
-        shell: bash
-        run: |
-          cd "${{ inputs.package-path }}"
-          org="$(jq '.name|split("/")|.[0]' package.json)"
-          if [[ $org == "\"@solana-program\"" ]] then
-            if [ -z ${SOLANA_PROGRAM_NPM_TOKEN} ]; then
-              echo "The SOLANA_PROGRAM_NPM_TOKEN secret variable is not set"
-              echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
-              exit 1
-            fi
-            pnpm config set '//registry.npmjs.org/:_authToken' "${SOLANA_PROGRAM_NPM_TOKEN}"
-          elif [[ $org == "\"@solana\"" ]] then
-            echo "Using NPM Trusted Publishers via OIDC"
-            echo "NPM_CONFIG_PROVENANCE=true" >> "${GITHUB_ENV}"
-          else
-            echo "Unknown organization: $org"
-            exit 1
-          fi
-
       - name: Set Git Author
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf https://github.com/
 
       - name: Publish
         id: publish
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
         shell: bash
         run: |
           echo "old_git_tag=$(make git-tag-js-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

Removes `ANZA_TEAM_PAT` and `SOLANA_PROGRAM_NPM_TOKEN` from the JS publish workflow, extending the same supply chain hardening from the Rust workflow to JS packages.

- Trusted publishing for `@solana-program`: removes the static npm token in favour of OIDC,  both `@solana` and `@solana-program` packages now authenticate via trusted publishing
- GitHub App: replaces the PAT for git operations, enabling a tag protection ruleset that only the App can bypass
- Environment gate* publish job runs under `environment: prod`, allowing consuming repos to require manual approval before secrets are accessed

## Setup required in each consuming repo

- Create a `prod` environment with `APP_ID` variable and `PRIVATE_KEY` secret (same App as Rust workflow)
- Configure npm trusted publishing on npmjs.com for each `@solana-program/*` package (workflow: caller workflow file, environment: `prod`)
