### PR TITLE
publish rust: semver option

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -44,6 +44,11 @@ on:
         description: Create a GitHub release
         required: true
         type: boolean
+      run-semver:
+        description: Run semver checks
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   test:
@@ -129,7 +134,7 @@ jobs:
           cargo release $LEVEL --manifest-path "${{ inputs.package-path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
 
       - name: Check semver
-        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
+        if: ${{ steps.has_lib.outputs.has_lib == 'true' && inputs.run-semver }}
         run: cargo semver-checks --manifest-path "${{ inputs.package-path }}/Cargo.toml"
 
   publish:


### PR DESCRIPTION
Provides consumers the ability to opt out of semver checks.

Relevant to https://github.com/solana-program/libraries/actions/runs/23888453532 where it's attempting a version that knowingly does not pass the check. 