### PR TITLE
build(deps): bump actions/cache from 4 to 5 in install-solana

### DIFF
--- a/install-solana/action.yml
+++ b/install-solana/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Cache Version
       id: cache
       if: inputs.cache == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.local/share/solana/install/releases


### PR DESCRIPTION
## Summary

- Bumps `actions/cache` from v4 to v5 in `install-solana/action.yml`
- PR #24 bumped this dependency in `.github/workflows/main.yml` but missed the composite action that consumers use
- Every workflow using `install-solana` with `cache: true` currently emits a Node.js 20 deprecation warning:

  > Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4.

## Timeline

- **June 2, 2026**: Node.js 20 actions forced to run on Node.js 24
- **Fall 2026**: Node.js 20 removed from runners entirely

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/