### PR TITLE
main: Use cargo-install fallback for mollusk-svm-cli

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -409,6 +409,7 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: mollusk-svm-cli,toml-cli
+          fallback: cargo-install
 
       - name: Restore Program Builds
         uses: actions/cache/restore@v5


### PR DESCRIPTION
#### Problem

The regression jobs are failing to install the mollusk CLI because the install action uses `cargo-binstall`, which isn't supported by the mollusk CLI.

#### Summary of changes

Fallback to using cargo-install instead. In the future, we can make the mollusk CLI compatible with cargo-binstall, but let's unblock for now.

Some notes: this uses the `fallback` option for the install-action: https://github.com/taiki-e/install-action#supported-tools

Here's a failing run where cargo-binstall isn't working for mollusk-svm-cli: https://github.com/solana-program/address-lookup-table/actions/runs/25044549392/job/73356700941?pr=249