### PR TITLE
main: Install with cache-cargo-install-action instead

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -405,11 +405,15 @@ jobs:
           cli: true
           cargo-cache-key: cargo-regression-${{ matrix.package }}
 
-      - name: Install mollusk and toml
-        uses: taiki-e/install-action@v2
+      - name: Install mollusk
+        uses: taiki-e/cache-cargo-install-action@v3
         with:
-          tool: mollusk-svm-cli,toml-cli
-          fallback: cargo-install
+          tool: mollusk-svm-cli
+
+      - name: Install toml
+        uses: taiki-e/cache-cargo-install-action@v3
+        with:
+          tool: toml-cli
 
       - name: Restore Program Builds
         uses: actions/cache/restore@v5


### PR DESCRIPTION
#### Problem

There's still an issue installing the CLIs, because they're not part of the supported list of tools.

#### Summary of changes

Switch to cache-cargo-install-action, which caches *and* falls back to cargo install, which avoids re-installing the tools.