### PR TITLE
no-std checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,12 +64,16 @@ on:
         description: Install Solana specified as a major-minor-patch version, e.g. `"2.3.4"`.
         required: false
         type: string
-      no-std-packages:
-        description: JSON array of no_std checks. Each entry runs `make check-no-std-<package>` with `-Zbuild-std=<build_std>` and optional `--exclude-features <exclude_features>`, e.g. `[{"package":"spl-token-2022-interface","build_std":"alloc,core","exclude_features":"std,serde"}]`.
+      no-std-core-packages:
+        description: no_std core-only packages to check as a JSON-encoded array of strings, e.g. `["packageA", "packageB"]`. Each entry runs `make check-no-std-core-<package>`.
+        required: false
+        type: string
+      no-std-alloc-packages:
+        description: no_std alloc packages to check as a JSON-encoded array of strings, e.g. `["packageA", "packageB"]`. Each entry runs `make check-no-std-alloc-<package>`.
         required: false
         type: string
       no-std-toolchain:
-        description: Nightly toolchain for no_std checks. Required when no-std-packages is provided because `-Zbuild-std` is nightly-only, e.g. "nightly-2025-02-16".
+        description: Nightly toolchain for no_std checks. Required when no-std-core-packages or no-std-alloc-packages is provided because `-Zbuild-std` is nightly-only, e.g. "nightly-2025-02-16".
         required: false
         type: string
 
@@ -534,42 +538,24 @@ jobs:
       - name: Test
         run: make test-py-${{ matrix.package }}
 
-  no_std_packages:
-    name: Check no-std (${{ matrix.package }})
+  no_std_core_packages:
+    name: Check no-std core (${{ matrix.package }})
     runs-on: ubuntu-latest
-    if: ${{ inputs.no-std-packages }}
+    if: ${{ inputs.no-std-core-packages }}
     strategy:
       matrix:
-        include: ${{ fromJson(inputs.no-std-packages) }}
+        package: ${{ fromJson(inputs.no-std-core-packages) }}
       fail-fast: false
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
-
-      - name: Validate inputs
-        shell: bash
-        env:
-          NO_STD_TOOLCHAIN: ${{ inputs.no-std-toolchain }}
-        run: |
-          if [ -z "$NO_STD_TOOLCHAIN" ]; then
-            echo "no-std-toolchain is required when no-std-packages is provided"
-            exit 1
-          fi
-          if [ -z '${{ matrix.package }}' ]; then
-            echo "no-std-packages entries must include package"
-            exit 1
-          fi
-          if [ -z '${{ matrix.build_std }}' ]; then
-            echo "no-std-packages entries must include build_std"
-            exit 1
-          fi
 
       - name: Setup Environment
         uses: solana-program/actions/setup-ubuntu@main
         with:
           nightly-toolchain: ${{ inputs.no-std-toolchain }}
           rust-components: rust-src
-          cargo-cache-key: cargo-no-std-${{ matrix.package }}
+          cargo-cache-key: cargo-no-std-core-${{ matrix.package }}
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2
@@ -578,9 +564,32 @@ jobs:
 
       - name: Check no-std
         shell: bash
-        run: |
-          args='-Zbuild-std=${{ matrix.build_std }}'
-          if [ -n '${{ matrix.exclude_features }}' ]; then
-            args="$args --exclude-features ${{ matrix.exclude_features }}"
-          fi
-          make 'check-no-std-${{ matrix.package }}' ARGS="$args"
+        run: make 'check-no-std-core-${{ matrix.package }}'
+
+  no_std_alloc_packages:
+    name: Check no-std alloc (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    if: ${{ inputs.no-std-alloc-packages }}
+    strategy:
+      matrix:
+        package: ${{ fromJson(inputs.no-std-alloc-packages) }}
+      fail-fast: false
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: solana-program/actions/setup-ubuntu@main
+        with:
+          nightly-toolchain: ${{ inputs.no-std-toolchain }}
+          rust-components: rust-src
+          cargo-cache-key: cargo-no-std-alloc-${{ matrix.package }}
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: Check no-std
+        shell: bash
+        run: make 'check-no-std-alloc-${{ matrix.package }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -539,7 +539,7 @@ jobs:
         run: make test-py-${{ matrix.package }}
 
   no_std_core_packages:
-    name: Check no-std core (${{ matrix.package }})
+    name: Check no-std core
     runs-on: ubuntu-latest
     if: ${{ inputs.no-std-core-packages }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -567,7 +567,7 @@ jobs:
         run: make 'check-no-std-core-${{ matrix.package }}'
 
   no_std_alloc_packages:
-    name: Check no-std alloc (${{ matrix.package }})
+    name: Check no-std alloc
     runs-on: ubuntu-latest
     if: ${{ inputs.no-std-alloc-packages }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,14 @@ on:
         description: Install Solana specified as a major-minor-patch version, e.g. `"2.3.4"`.
         required: false
         type: string
+      no-std-packages:
+        description: JSON array of no_std checks. Each entry runs `make check-no-std-<package>` with `-Zbuild-std=<build_std>` and optional `--exclude-features <exclude_features>`, e.g. `[{"package":"spl-token-2022-interface","build_std":"alloc,core","exclude_features":"std,serde"}]`.
+        required: false
+        type: string
+      no-std-toolchain:
+        description: Nightly toolchain for no_std checks. Required when no-std-packages is provided because `-Zbuild-std` is nightly-only, e.g. "nightly-2025-02-16".
+        required: false
+        type: string
 
 jobs:
   format_and_lint_js:
@@ -525,3 +533,54 @@ jobs:
 
       - name: Test
         run: make test-py-${{ matrix.package }}
+
+  no_std_packages:
+    name: Check no-std (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    if: ${{ inputs.no-std-packages }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(inputs.no-std-packages) }}
+      fail-fast: false
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate inputs
+        shell: bash
+        env:
+          NO_STD_TOOLCHAIN: ${{ inputs.no-std-toolchain }}
+        run: |
+          if [ -z "$NO_STD_TOOLCHAIN" ]; then
+            echo "no-std-toolchain is required when no-std-packages is provided"
+            exit 1
+          fi
+          if [ -z '${{ matrix.package }}' ]; then
+            echo "no-std-packages entries must include package"
+            exit 1
+          fi
+          if [ -z '${{ matrix.build_std }}' ]; then
+            echo "no-std-packages entries must include build_std"
+            exit 1
+          fi
+
+      - name: Setup Environment
+        uses: solana-program/actions/setup-ubuntu@main
+        with:
+          nightly-toolchain: ${{ inputs.no-std-toolchain }}
+          rust-components: rust-src
+          cargo-cache-key: cargo-no-std-${{ matrix.package }}
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: Check no-std
+        shell: bash
+        run: |
+          args='-Zbuild-std=${{ matrix.build_std }}'
+          if [ -n '${{ matrix.exclude_features }}' ]; then
+            args="$args --exclude-features ${{ matrix.exclude_features }}"
+          fi
+          make 'check-no-std-${{ matrix.package }}' ARGS="$args"

--- a/setup-ubuntu/action.yml
+++ b/setup-ubuntu/action.yml
@@ -42,6 +42,10 @@ inputs:
   purge:
     description: Purge unused directories if `true`. Defaults to `false`.
     required: false
+  rust-components:
+    description: Rust components to install for configured toolchains, e.g. `rust-src`.
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -107,12 +111,14 @@ runs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.RUST_TOOLCHAIN_DEFAULT }}
+        components: ${{ inputs.rust-components }}
 
     - name: Install nightly toolchain
       if: ${{ inputs.nightly-toolchain != 'false' }}
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.nightly-toolchain }}
+        components: ${{ inputs.rust-components }}
 
     - name: Install Rustfmt
       if: ${{ inputs.rustfmt-toolchain != 'false' }}


### PR DESCRIPTION
Introduces optional no-std package checks to the main action.

### API

Consumers provide package lists by no-std mode:

- `no-std-core-packages` runs `make check-no-std-core-<package>`
- `no-std-alloc-packages` runs `make check-no-std-alloc-<package>`

The consumer owns the exact `cargo hack` flags (and any necessary excludes) for each mode:

```makefile
check-no-std-core-%:
	cargo $(nightly) hack check \
		--target bpfel-unknown-none \
		--each-feature \
		--package $* \
		-Zbuild-std=core \
		$(ARGS)

check-no-std-alloc-%:
	cargo $(nightly) hack check \
		--target bpfel-unknown-none \
		--each-feature \
		--package $* \
		-Zbuild-std=alloc,core \
		--exclude-features serde \
		$(ARGS)
```

Workflow usage looks like:


```yml
name: Main

on:
  push:
    branches: [main]
  pull_request:
    branches: [main]

env:
  NO_STD_ALLOC_PACKAGES: "['spl-token-2022-interface']"

jobs:
  set_env:
    name: Set variables to be used in strategy definitions in reusable workflow
    runs-on: ubuntu-latest
    outputs:
      RUST_TOOLCHAIN_NIGHTLY: ${{ steps.compute.outputs.RUST_TOOLCHAIN_NIGHTLY }}
      NO_STD_ALLOC_PACKAGES: ${{ steps.compute.outputs.NO_STD_ALLOC_PACKAGES }}
    steps:
      - name: Git Checkout
        uses: actions/checkout@v4

      - name: Compute variables
        id: compute
        shell: bash
        run: |
          {
            echo "RUST_TOOLCHAIN_NIGHTLY=$(make rust-toolchain-nightly)"
            echo "NO_STD_ALLOC_PACKAGES=${{ env.NO_STD_ALLOC_PACKAGES }}"
          } >> "$GITHUB_OUTPUT"

  main:
    needs: set_env
    uses: solana-program/actions/.github/workflows/main.yml@main
    with:
      no-std-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}
      no-std-alloc-packages: ${{ needs.set_env.outputs.NO_STD_ALLOC_PACKAGES }}

```