### PR TITLE
Install toml-cli on setup

### DIFF
--- a/setup-ubuntu/action.yml
+++ b/setup-ubuntu/action.yml
@@ -56,6 +56,11 @@ runs:
         RUST_TOOLCHAIN_DEFAULT=$(grep "channel =" ./rust-toolchain.toml | sed "s/channel = \"\(.*\)\"/\1/")
         echo "RUST_TOOLCHAIN_DEFAULT=$RUST_TOOLCHAIN_DEFAULT" >> "$GITHUB_ENV"
 
+    - name: Install toml-cli
+      uses: taiki-e/install-action@v2
+      with:
+        tool: toml-cli
+
     - name: Setup pnpm
       if: ${{ inputs.pnpm == 'true' }}
       uses: pnpm/action-setup@v5


### PR DESCRIPTION
Context: https://github.com/solana-program/token-2022/pull/1173

A likely standard approach going forward of declaring solana version (https://github.com/solana-program/token-2022/pull/1162#discussion_r3243223362) requires toml cli installed. This PR installs it by default on setup.