### PR TITLE
Make generate_clients job optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ on:
         description: The Rust toolchain for wasm builds, e.g. "nightly-2025-02-16"
         required: false
         type: string
-        default: 'default'
+        default: "default"
       wasm-js-packages:
         description: Rust packages to build with wasm-pack, e.g. `["package", "package2"]`.
         required: false
@@ -76,6 +76,11 @@ on:
         description: Nightly toolchain for no_std checks. Required when no-std-core-packages or no-std-alloc-packages is provided because `-Zbuild-std` is nightly-only, e.g. "nightly-2025-02-16".
         required: false
         type: string
+      generate-clients:
+        description: Whether to run the generate_clients job.
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   format_and_lint_js:
@@ -464,6 +469,7 @@ jobs:
   generate_clients:
     name: Check Client Generation
     runs-on: ubuntu-latest
+    if: ${{ inputs.generate-clients }}
     steps:
       - name: Git Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Adds a `generate-clients` boolean input to `main.yml` (defaulting to `true`) and conditionally runs the `generate_clients` job based on this flag.

Previously, the job ran unconditionally and enforced `pnpm: true` during the Ubuntu setup. This caused CI pipelines for pure rust repositories (which lack a `package.json`) to crash during the environment setup phase (https://github.com/solana-program/secp256k1/pull/12). This change allows rust-only repositories opt out without breaking existing downstream consumers.