### PR TITLE
ci: fix cache issue

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -48,21 +48,29 @@ jobs:
           cache: false
 
       - name: Format
-        run: make format-check-js-${{ inputs.target }}
+        env:
+          TARGET: ${{ inputs.target }}
+        run: make "format-check-js-${TARGET}"
 
       - name: Lint
-        run: make lint-js-${{ inputs.target }}
+        env:
+          TARGET: ${{ inputs.target }}
+        run: make "lint-js-${TARGET}"
 
       - name: Build programs
         shell: bash
+        env:
+          SBPF_PROGRAM_PACKAGES: ${{ inputs.sbpf-program-packages }}
         run: |
-          for program in ${{ inputs.sbpf-program-packages }}
+          for program in $SBPF_PROGRAM_PACKAGES
           do
-            make build-sbf-$program
+            make "build-sbf-${program}"
           done
 
       - name: Test
-        run: make test-js-${{ inputs.target }}
+        env:
+          TARGET: ${{ inputs.target }}
+        run: make "test-js-${TARGET}"
 
       - name: Write check summary
         shell: bash
@@ -128,17 +136,22 @@ jobs:
         id: publish
         env:
           NPM_CONFIG_PROVENANCE: "true"
+          LEVEL: ${{ inputs.level }}
+          TAG: ${{ inputs.tag }}
+          TARGET: ${{ inputs.target }}
         shell: bash
         run: |
-          echo "old_git_tag=$(make git-tag-js-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
-          LEVEL=${{ inputs.level }} TAG=${{ inputs.tag }} make publish-js-${{ inputs.target }}
-          echo "new_git_tag=$(make git-tag-js-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
+          echo "old_git_tag=$(make "git-tag-js-${TARGET}")" >> "${GITHUB_OUTPUT}"
+          LEVEL="$LEVEL" TAG="$TAG" make "publish-js-${TARGET}"
+          echo "new_git_tag=$(make "git-tag-js-${TARGET}")" >> "${GITHUB_OUTPUT}"
 
       - name: Git Commit Bump, Tag, and Push
         shell: bash
+        env:
+          NEW_GIT_TAG: ${{ steps.publish.outputs.new_git_tag }}
         run: |
-          git commit -am "Publish ${{ steps.publish.outputs.new_git_tag }}"
-          git tag -a "${{ steps.publish.outputs.new_git_tag }}" -m "Publish ${{ steps.publish.outputs.new_git_tag }}"
+          git commit -am "Publish ${NEW_GIT_TAG}"
+          git tag -a "${NEW_GIT_TAG}" -m "Publish ${NEW_GIT_TAG}"
           git push origin --follow-tags
 
       - name: Generate a changelog

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -45,8 +45,7 @@ jobs:
         with:
           pnpm: true
           solana: ${{ inputs.solana-cli-version }}
-          cargo-cache-key: cargo-publish-js-test-${{ inputs.package-path }}
-          cargo-cache-fallback-key: cargo-publish-js-test
+          cache: false
 
       - name: Format
         run: make format-check-js-${{ inputs.target }}
@@ -115,6 +114,7 @@ jobs:
         uses: solana-program/actions/setup-ubuntu@main
         with:
           pnpm: true
+          cache: false
 
       - name: Set Git Author
         env:

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -66,8 +66,7 @@ jobs:
           solana: ${{ inputs.solana-cli-version }}
           cli: true
           purge: true
-          cargo-cache-key: cargo-test-publish-${{ inputs.package-path }}
-          cargo-cache-fallback-key: cargo-test-publish
+          cache: false
 
       - name: Format
         run: make format-check-${{ inputs.target }}
@@ -97,8 +96,7 @@ jobs:
         uses: solana-program/actions/setup-ubuntu@main
         with:
           cli: true
-          cargo-cache-key: cargo-publish-semver-${{ inputs.package-path }}
-          cargo-cache-fallback-key: cargo-publish-semver
+          cache: false
 
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@v2
@@ -187,8 +185,7 @@ jobs:
         uses: solana-program/actions/setup-ubuntu@main
         with:
           cli: true
-          cargo-cache-key: cargo-publish-${{ inputs.package-path }}
-          cargo-cache-fallback-key: cargo-publish
+          cache: false
 
       - name: Install cargo-release and toml-cli
         uses: taiki-e/install-action@v2

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -69,21 +69,29 @@ jobs:
           cache: false
 
       - name: Format
-        run: make format-check-${{ inputs.target }}
+        env:
+          TARGET: ${{ inputs.target }}
+        run: make "format-check-${TARGET}"
 
       - name: Clippy
-        run: make clippy-${{ inputs.target }}
+        env:
+          TARGET: ${{ inputs.target }}
+        run: make "clippy-${TARGET}"
 
       - name: Build programs
         shell: bash
+        env:
+          SBPF_PROGRAM_PACKAGES: ${{ inputs.sbpf-program-packages }}
         run: |
-          for program in ${{ inputs.sbpf-program-packages }}
+          for program in $SBPF_PROGRAM_PACKAGES
           do
-            make build-sbf-$program
+            make "build-sbf-${program}"
           done
 
       - name: Test
-        run: make test-${{ inputs.target }}
+        env:
+          TARGET: ${{ inputs.target }}
+        run: make "test-${TARGET}"
 
   semver:
     name: Check Semver
@@ -106,9 +114,11 @@ jobs:
       - name: Check if crate has a lib target
         id: has_lib
         shell: bash
+        env:
+          PACKAGE_PATH: ${{ inputs.package-path }}
         run: |
           set +e # toml crashes the whole shell if it fails to find the key
-          result=$(toml get "${{ inputs.package-path }}/Cargo.toml" lib.crate-type)
+          result=$(toml get "${PACKAGE_PATH}/Cargo.toml" lib.crate-type)
           if [[ "$result" == *"lib"* ]]; then
             echo "has_lib=true" >> "$GITHUB_OUTPUT"
           else
@@ -121,13 +131,15 @@ jobs:
           git config --global user.name "github-actions[bot]"
 
       - name: Set Version
+        env:
+          LEVEL: ${{ inputs.level }}
+          VERSION: ${{ inputs.version }}
+          PACKAGE_PATH: ${{ inputs.package-path }}
         run: |
-          if [ "${{ inputs.level }}" == "version" ]; then
-            LEVEL=${{ inputs.version }}
-          else
-            LEVEL=${{ inputs.level }}
+          if [ "$LEVEL" == "version" ]; then
+            LEVEL="$VERSION"
           fi
-          cargo release $LEVEL --manifest-path "${{ inputs.package-path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
+          cargo release "$LEVEL" --manifest-path "${PACKAGE_PATH}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
 
       - name: Write check summary
         shell: bash
@@ -155,7 +167,9 @@ jobs:
 
       - name: Check semver
         if: ${{ steps.has_lib.outputs.has_lib == 'true' && inputs.run-semver }}
-        run: cargo semver-checks --manifest-path "${{ inputs.package-path }}/Cargo.toml"
+        env:
+          PACKAGE_PATH: ${{ inputs.package-path }}
+        run: cargo semver-checks --manifest-path "${PACKAGE_PATH}/Cargo.toml"
 
   publish:
     name: Publish Rust Crate
@@ -207,26 +221,30 @@ jobs:
         id: publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          LEVEL: ${{ inputs.level }}
+          VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          TARGET: ${{ inputs.target }}
         run: |
-          if [ "${{ inputs.level }}" == "version" ]; then
-            LEVEL=${{ inputs.version }}
-          else
-            LEVEL=${{ inputs.level }}
+          if [ "$LEVEL" == "version" ]; then
+            LEVEL="$VERSION"
           fi
 
-          if [ "${{ inputs.dry-run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             OPTIONS="dry-run-"
           else
             OPTIONS=""
           fi
 
-          echo "old_git_tag=$(make git-tag-rust-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
-          LEVEL=${LEVEL} make publish-rust-${OPTIONS}${{ inputs.target }}
-          echo "new_git_tag=$(make git-tag-rust-${{ inputs.target }})" >> "${GITHUB_OUTPUT}"
+          echo "old_git_tag=$(make "git-tag-rust-${TARGET}")" >> "${GITHUB_OUTPUT}"
+          LEVEL="$LEVEL" make "publish-rust-${OPTIONS}${TARGET}"
+          echo "new_git_tag=$(make "git-tag-rust-${TARGET}")" >> "${GITHUB_OUTPUT}"
 
       - name: Package crate for attestation
         if: ${{ inputs.dry-run == false }}
-        run: cargo package --no-verify --manifest-path "${{ inputs.package-path }}/Cargo.toml"
+        env:
+          PACKAGE_PATH: ${{ inputs.package-path }}
+        run: cargo package --no-verify --manifest-path "${PACKAGE_PATH}/Cargo.toml"
 
       - name: Generate SLSA provenance
         if: ${{ inputs.dry-run == false }}

--- a/setup-ubuntu/action.yml
+++ b/setup-ubuntu/action.yml
@@ -39,6 +39,10 @@ inputs:
   cli:
     description: Install CLI dependencies if `true`. Defaults to `false`.
     required: false
+  cache:
+    description: Enable dependency caching (pnpm, Solana, cargo) if `true`. Defaults to `true`.
+    required: false
+    default: 'true'
   purge:
     description: Purge unused directories if `true`. Defaults to `false`.
     required: false
@@ -70,7 +74,7 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: 24
-        cache: 'pnpm'
+        cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}
 
     - name: Install Dependencies
       if: ${{ inputs.pnpm == 'true' }}
@@ -144,7 +148,7 @@ runs:
       uses: solana-program/actions/install-solana@v1
       with:
         version: ${{ inputs.solana }}
-        cache: true
+        cache: ${{ inputs.cache }}
 
     - name: Install CLI dependencies
       if: ${{ inputs.cli == 'true' }}
@@ -167,7 +171,7 @@ runs:
       run: cargo +"${{ inputs.nightly-toolchain }}" miri setup
 
     - name: Cache Cargo Dependencies
-      if: ${{ inputs.cargo-cache-key && !inputs.cargo-cache-fallback-key }}
+      if: ${{ inputs.cache == 'true' && inputs.cargo-cache-key && !inputs.cargo-cache-fallback-key }}
       uses: actions/cache@v5
       with:
         path: |
@@ -180,7 +184,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.cargo-cache-key }}
 
     - name: Cache Cargo Dependencies With Fallback
-      if: ${{ inputs.cargo-cache-key && inputs.cargo-cache-fallback-key }}
+      if: ${{ inputs.cache == 'true' && inputs.cargo-cache-key && inputs.cargo-cache-fallback-key }}
       uses: actions/cache@v5
       with:
         path: |
@@ -196,7 +200,7 @@ runs:
           ${{ runner.os }}-${{ inputs.cargo-cache-fallback-key }}
 
     - name: Cache Local Cargo Dependencies
-      if: ${{ inputs.cargo-cache-local-key }}
+      if: ${{ inputs.cache == 'true' && inputs.cargo-cache-local-key }}
       uses: actions/cache@v5
       with:
         path: |


### PR DESCRIPTION
Two hardening changes to the Rust and JS publish workflows, following [pinocchio#434](https://github.com/anza-xyz/pinocchio/pull/434).

## Drop caching in the publish flow

The gated `publish` jobs restored caches that unprotected jobs in the same flow also wrote to. Keys aren't scoped by environment and `restore-keys` match by prefix, so an unprotected job could seed a cache the privileged publish job later restores and runs under the publish token.

Added a `cache` input to `setup-ubuntu` (defaults to `true`, so CI is unchanged) that gates the pnpm, Solana, and cargo caches, and set `cache: false` on the publish setup steps.

## Pass inputs via env vars

Free-form inputs (`version`, `level`, `tag`, etc.) were interpolated straight into `run:` scripts, allowing shell injection. They're now bound to step `env:` and used as quoted shell variables.
