### PR TITLE
Skip changelog and release when previous tag is missing

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -149,7 +149,7 @@ jobs:
           if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
             echo "exists=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::warning::Previous tag '${TAG}' not found in git history; skipping changelog and GitHub release for this run."
+            echo "::warning::Previous tag '${TAG}' not found in git history; skipping changelog generation and creating the release without notes. To add notes, run \`git-cliff -c scripts/cliff.toml <SOURCE_REF>..${{ steps.publish.outputs.new_git_tag }} --include-path \"${{ inputs.package-path }}/**\" --github-repo ${{ github.repository }}\` with a suitable source ref, then paste the output into the new GitHub release."
             echo "exists=false" >> "${GITHUB_OUTPUT}"
           fi
 
@@ -164,8 +164,8 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create GitHub release
-        if: github.event.inputs.create-release == 'true' && steps.prev_tag.outputs.exists == 'true'
+        if: github.event.inputs.create-release == 'true'
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.publish.outputs.new_git_tag }}
-          bodyFile: TEMP_CHANGELOG.md
+          bodyFile: ${{ steps.prev_tag.outputs.exists == 'true' && 'TEMP_CHANGELOG.md' || '' }}

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -141,8 +141,20 @@ jobs:
           git tag -a "${{ steps.publish.outputs.new_git_tag }}" -m "Publish ${{ steps.publish.outputs.new_git_tag }}"
           git push origin --follow-tags
 
+      - name: Check previous tag exists
+        id: prev_tag
+        shell: bash
+        run: |
+          TAG="${{ steps.publish.outputs.old_git_tag }}"
+          if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::warning::Previous tag '${TAG}' not found in git history; skipping changelog and GitHub release for this run."
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Generate a changelog
-        if: github.event.inputs.create-release == 'true'
+        if: github.event.inputs.create-release == 'true' && steps.prev_tag.outputs.exists == 'true'
         uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
@@ -152,7 +164,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create GitHub release
-        if: github.event.inputs.create-release == 'true'
+        if: github.event.inputs.create-release == 'true' && steps.prev_tag.outputs.exists == 'true'
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.publish.outputs.new_git_tag }}

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -239,8 +239,20 @@ jobs:
         with:
           subject-path: target/package/*.crate
 
+      - name: Check previous tag exists
+        id: prev_tag
+        shell: bash
+        run: |
+          TAG="${{ steps.publish.outputs.old_git_tag }}"
+          if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::warning::Previous tag '${TAG}' not found in git history; skipping changelog and GitHub release for this run."
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Generate a changelog
-        if: github.event.inputs.create-release == 'true'
+        if: github.event.inputs.create-release == 'true' && steps.prev_tag.outputs.exists == 'true'
         uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
@@ -250,7 +262,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create GitHub release
-        if: github.event.inputs.create-release == 'true' && github.event.inputs.dry-run != 'true'
+        if: github.event.inputs.create-release == 'true' && github.event.inputs.dry-run != 'true' && steps.prev_tag.outputs.exists == 'true'
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.publish.outputs.new_git_tag }}

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -247,7 +247,7 @@ jobs:
           if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
             echo "exists=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::warning::Previous tag '${TAG}' not found in git history; skipping changelog and GitHub release for this run."
+            echo "::warning::Previous tag '${TAG}' not found in git history; skipping changelog generation and creating the release without notes. To add notes, run \`git-cliff -c scripts/cliff.toml <SOURCE_REF>..${{ steps.publish.outputs.new_git_tag }} --include-path \"${{ inputs.package-path }}/**\" --github-repo ${{ github.repository }}\` with a suitable source ref, then paste the output into the new GitHub release."
             echo "exists=false" >> "${GITHUB_OUTPUT}"
           fi
 
@@ -262,8 +262,8 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create GitHub release
-        if: github.event.inputs.create-release == 'true' && github.event.inputs.dry-run != 'true' && steps.prev_tag.outputs.exists == 'true'
+        if: github.event.inputs.create-release == 'true' && github.event.inputs.dry-run != 'true'
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.publish.outputs.new_git_tag }}
-          bodyFile: TEMP_CHANGELOG.md
+          bodyFile: ${{ steps.prev_tag.outputs.exists == 'true' && 'TEMP_CHANGELOG.md' || '' }}


### PR DESCRIPTION
This PR makes the reusable JS and Rust publish workflows resilient to a missing previous git tag. `git cliff` computes the changelog from `<old_git_tag>..HEAD`; when that tag was never pushed to the remote (e.g. a prior run that split the registry and git), the revspec does not exist and `git cliff` hard-fails, aborting the run after publish.

A new `Check previous tag exists` step now verifies the tag via `git rev-parse` and, when absent, emits a warning and skips both the changelog and GitHub release steps so the run succeeds instead of failing post-publish.