### PR TITLE
Guard Rust publish against stale commits

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -203,6 +203,31 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf https://github.com/
 
+      # Guard the irreversible crate publish below: if `main` advanced after this
+      # run was dispatched (e.g. a PR merged in the meantime), the checked-out
+      # tree no longer matches what the `test` job validated. Abort before
+      # publishing so the run can be re-dispatched from the current tip, rather
+      # than leaving the registry and git in a split state.
+      - name: Ensure branch is up to date
+        if: ${{ inputs.dry-run == false }}
+        shell: bash
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+          git fetch --quiet origin "${BRANCH}"
+          HEAD_SHA=$(git rev-parse HEAD)
+          REMOTE_SHA=$(git rev-parse "origin/${BRANCH}")
+          if [ "${HEAD_SHA}" != "${REMOTE_SHA}" ] || [ "${GITHUB_SHA}" != "${REMOTE_SHA}" ]; then
+            {
+              echo "::error::Refusing to publish: the run is not on the latest commit of '${BRANCH}'."
+              echo "  dispatched sha : ${GITHUB_SHA}"
+              echo "  checked-out sha: ${HEAD_SHA}"
+              echo "  origin tip     : ${REMOTE_SHA}"
+              echo "Re-run the publish workflow from the current tip of '${BRANCH}'."
+            } >&2
+            exit 1
+          fi
+          echo "Up to date with origin/${BRANCH} at ${REMOTE_SHA}."
+
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5
         id: auth
 


### PR DESCRIPTION
See https://github.com/solana-program/actions/pull/52. In case we want to do the same for the Rust workflow. Feel free to close otherwise. ☺️